### PR TITLE
Add flag option to prevent wrap as fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ const parseSelector = require('hast-util-parse-selector');
  * Attacher
  */
 module.exports = options => {
-  options = options || { fallback: true };
+  options = options || {};
   const selector = options.selector || options.select || 'body';
   const wrapper = options.wrapper || options.wrap;
-  const fallback = options.fallback;
+  const fallback = options.fallback !== undefined ? options.fallback : true;
 
   /*
    * Transformer
@@ -26,6 +26,10 @@ module.exports = options => {
 
     if (typeof selector !== 'string') {
       throw new TypeError('Expected a `string` as selector');
+    }
+
+    if (typeof fallback !== 'boolean') {
+      throw new TypeError('Expected a `boolean` as fallback');
     }
 
     const selected = select.select(selector, tree);

--- a/index.js
+++ b/index.js
@@ -11,9 +11,10 @@ const parseSelector = require('hast-util-parse-selector');
  * Attacher
  */
 module.exports = options => {
-  options = options || {};
+  options = options || { fallback: true };
   const selector = options.selector || options.select || 'body';
   const wrapper = options.wrapper || options.wrap;
+  const fallback = options.fallback;
 
   /*
    * Transformer
@@ -40,7 +41,7 @@ module.exports = options => {
           parent.children[i] = wrap;
         }
       });
-    } else {
+    } else if (fallback) {
       wrap.children = tree.children;
       tree.children = [wrap];
     }

--- a/test.js
+++ b/test.js
@@ -44,6 +44,14 @@ test('rehype-wrap', t => {
       /Expected a `string` as selector/,
       ' if selector is not a string'
     );
+
+    it.throws(
+      () => {
+        vfile = process(wrap, {wrap: 'a', select: 'p', fallback: 1}, markdown);
+      },
+      /Expected a `boolean` as fallback/,
+      ' if fallback is not a boolean'
+    );
     it.end();
   });
 
@@ -100,7 +108,27 @@ test('rehype-wrap', t => {
           '<div><pre><code class="language-js">const foo = \'bar\'',
           '</code></pre></div>'
         ].join('\n'),
-        'should match with wrap dive and selector pre'
+        'should match with wrap div and selector pre'
+      );
+
+      vfile = process(
+        wrap,
+        {
+          select: 'p',
+          wrap: 'div',
+          fallback: false
+        },
+        markdown
+      );
+
+      it.ok(
+        vfile.toString() ===
+        [
+          '<h1>Foo</h1>',
+          '<pre><code class="language-js">const foo = \'bar\'',
+          '</code></pre>'
+        ].join('\n'),
+        'should not wrap div as fallback if it does not match the selector p'
       );
 
       const ast = unified()


### PR DESCRIPTION
Hey there,
Thanks for this util! I've been using it to wrap embed youtube videos in div containers to handle responsive css.
I was finding a way to prevent the fallback wrap in case it couldn't find the selector param.
This is a first try. I've just added a boolean flag to disable that fallback but keeping `true` as default to provide retro compat.
I don't have any prev experience with rehype, so please feel free to suggest any change to make it better.